### PR TITLE
use `UNSAFE_` methods to support React 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prop-types": "^15.5.7"
   },
   "peerDependencies": {
-    "react": "15.x || 16.x"
+    "react": ">=16.3"
   },
   "devDependencies": {
     "@types/jest": "^20.0.8",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -170,7 +170,7 @@ export default class VirtualList extends React.PureComponent<Props, State> {
     }
   }
 
-  componentWillReceiveProps(nextProps: Props) {
+  UNSAFE_componentWillReceiveProps(nextProps: Props) {
     const {
       estimatedItemSize,
       itemCount,


### PR DESCRIPTION
Not sure how we'll want to consume this fork... but it will be ready for React 17 or strict mode